### PR TITLE
finishedPageAtIndex only called if failedPageAtIndex is defined due to copy&paste error

### DIFF
--- a/DLPDFRenderer/Classes/DLPRRenderer.m
+++ b/DLPDFRenderer/Classes/DLPRRenderer.m
@@ -45,7 +45,7 @@
 - (void)finishedLoadingPage {
 	NSUInteger pageIndex = self.currentPageIndex;
 	[self addLoadedPage];
-	if ([self.delegate respondsToSelector:@selector(renderer:failedPageAtIndex:)]) {
+	if ([self.delegate respondsToSelector:@selector(renderer:finishedPageAtIndex:)]) {
 		[self.delegate renderer:self finishedPageAtIndex:pageIndex];
 	}
 	if ([self.dataSource renderer:self hasReachedLastPageAtIndex:pageIndex]) {


### PR DESCRIPTION
When trying to call finishedPageAtIndex, it actually checks for the existence of failedPageAtIndex
